### PR TITLE
zope.event 5.0

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) 2015-2020, conda-forge contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,27 @@
-BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+BSD 3-Clause License
+
+Copyright (c) 2022, Anaconda, Inc.
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ test:
   requires:
     - pip
   commands:
-    - pip test
+    - pip check
 
 about:
   home: https://github.com/zopefoundation/zope.event

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,48 +1,51 @@
 {% set name = "zope.event" %}
-{% set version = "4.5.0" %}
-{% set file_ext = "tar.gz" %}
-{% set hash_type = "sha256" %}
-{% set hash_value = "5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330" %}
+{% set version = "5.0" %}
 
 package:
-  name: '{{ name|lower }}'
-  version: '{{ version }}'
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  fn: '{{ name }}-{{ version }}.{{ file_ext }}'
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
-  '{{ hash_type }}': '{{ hash_value }}'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: bac440d8d9891b4068e2b5a2c5e2c9765a9df762944bda6955f96bb9b91e67cd
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python
+    - pip
     - setuptools
+    - wheel
   run:
     - python
+    # https://github.com/zopefoundation/zope.event/blob/5.0/setup.py#L69
     - setuptools
 
 test:
   imports:
     - zope
     - zope.event
+  requires:
+    - pip
+  commands:
+    - pip test
 
 about:
-  home: http://www.zope.org/en/latest/
-  license: Zope Public License
+  home: https://github.com/zopefoundation/zope.event
+  license: ZPL-2.1
   license_family: OTHER
-  summary: Very basic event publishing system
+  summary: Event publishing / dispatch, used by Zope Component Architecture
   description: |
     This package provides a simple event system on which application-specific
     event systems can be built. For example, a type-based event dispatching
     system that builds on zope.interface can be found in zope.component. A
     simpler system is distributed with this package and is described in
     Class-based event handlers.
-  doc_url: http://zopeevent.readthedocs.io/en/latest/
-  dev_url: http://github.com/zopefoundation/zope.event
+  doc_url: https://zopeevent.readthedocs.io/
+  dev_url: https://github.com/zopefoundation/zope.event
 
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,13 +30,18 @@ test:
     - zope.event
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -vv --pyargs zope.event.tests
 
 about:
   home: https://github.com/zopefoundation/zope.event
   license: ZPL-2.1
   license_family: OTHER
+  license_file:
+    - LICENSE.txt
+    - COPYRIGHT.txt
   summary: Event publishing / dispatch, used by Zope Component Architecture
   description: |
     This package provides a simple event system on which application-specific

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - wheel
   run:
     - python
-    # https://github.com/zopefoundation/zope.event/blob/5.0/setup.py#L69
+    # https://github.com/zopefoundation/zope.event/blob/5.0/setup.py#L70
     - setuptools
 
 test:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-3684](https://anaconda.atlassian.net/browse/PKG-3684) 
- [Upstream repository](https://github.com/zopefoundation/zope.event)
- Changelog: https://github.com/zopefoundation/zope.event/blob/5.0/CHANGES.rst
- License: https://github.com/zopefoundation/zope.event/blob/5.0/LICENSE.txt
- Requirements: https://github.com/zopefoundation/zope.event/blob/5.0/setup.py

### Explanation of changes:

- Add the feedstock's license
- Remove redundant jinja variables
- Update `script`
- Add missing `pip` and `wheel` to `host`
- Add `pip check`
- Add `pytest`
- Update `home`, doc & dev url
- Update `license` as `ZPL-2.1`
- Update `summary`

### Notes:

- `gevent 23.9.1` requires zope.event for py312 https://github.com/AnacondaRecipes/gevent-feedstock/pull/5

[PKG-3684]: https://anaconda.atlassian.net/browse/PKG-3684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ