### PR TITLE
zope.event 6.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,28 +1,27 @@
 {% set name = "zope.event" %}
-{% set version = "5.0" %}
+{% set version = "6.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bac440d8d9891b4068e2b5a2c5e2c9765a9df762944bda6955f96bb9b91e67cd
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('.', '_')}}-{{ version }}.tar.gz
+  sha256: 6052a3e0cb8565d3d4ef1a3a7809336ac519bc4fe38398cb8d466db09adef4f0
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<310]
 
 requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=78.1.1,<81
     - wheel
   run:
     - python
-    # https://github.com/zopefoundation/zope.event/blob/5.0/setup.py#L70
-    - setuptools
 
 test:
   imports:
@@ -49,7 +48,7 @@ about:
     system that builds on zope.interface can be found in zope.component. A
     simpler system is distributed with this package and is described in
     Class-based event handlers.
-  doc_url: https://zopeevent.readthedocs.io/
+  doc_url: https://zopeevent.readthedocs.io
   dev_url: https://github.com/zopefoundation/zope.event
 
 


### PR DESCRIPTION
zope.event 6.1 

**Destination channel:** Defaults

### Links

- [PKG-10805]
- dev_url:        https://github.com/zopefoundation/zope.event/tree/6.1
- conda_forge:    https://github.com/conda-forge/zope.event-feedstock
- pypi:           https://pypi.org/project/zope.event/6.1
- pypi inspector: https://inspector.pypi.io/project/zope.event/6.1

### Explanation of changes:

- new version number


[PKG-10805]: https://anaconda.atlassian.net/browse/PKG-10805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ